### PR TITLE
modularize the key database

### DIFF
--- a/examples/http-signature-server/main.go
+++ b/examples/http-signature-server/main.go
@@ -95,7 +95,7 @@ func main() {
 		log.Fatal().Msgf("could not parse authorized keys file %s: %s", *authorizedKeys, err)
 	}
 
-	keysDB := http_signature_auth.NewKeysDatabase()
+	keysDB := http_signature_auth.NewMemoryKeysDatabase()
 	for i := range keys {
 		keysDB.AddKey(keyIDs[i], keys[i])
 	}

--- a/handler.go
+++ b/handler.go
@@ -8,9 +8,9 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func NewSignatureAuthHandler(keysDB *Keys, handlerFunc http.HandlerFunc) http.HandlerFunc {
+func NewSignatureAuthHandler(keysDB KeysDB, handlerFunc http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		
+
 		log.Debug().Msgf("Received request from %s", r.RemoteAddr)
 		dump, err := httputil.DumpRequest(r, true)
 		if err != nil {

--- a/keys.go
+++ b/keys.go
@@ -74,13 +74,19 @@ func (m *SyncMap[K, V]) Remove(key K) {
 	m.inner.Delete(key)
 }
 
+type KeysDB interface {
+	AddKey(id KeyID, key crypto.PublicKey) crypto.PublicKey
+	RemoveKey(id KeyID) crypto.PublicKey
+	GetKey(id KeyID) crypto.PublicKey
+}
+
 // currently a simple wrapper around a SyncMap
-type Keys struct {
+type MemoryKeysDB struct {
 	idToKeys SyncMap[KeyID, crypto.PublicKey]
 }
 
-func NewKeysDatabase() *Keys {
-	return &Keys{
+func NewMemoryKeysDatabase() KeysDB {
+	return &MemoryKeysDB{
 		idToKeys: SyncMap[KeyID, crypto.PublicKey]{},
 	}
 }
@@ -88,14 +94,14 @@ func NewKeysDatabase() *Keys {
 // AddKey adds a public key with the given Key ID to the database of keys.
 // Returns nil if no previous key was present with this ID, otherwise returns
 // the previous key.
-func (k *Keys) AddKey(id KeyID, key crypto.PublicKey) crypto.PublicKey {
+func (k *MemoryKeysDB) AddKey(id KeyID, key crypto.PublicKey) crypto.PublicKey {
 	previousKey, _ := k.idToKeys.Get(id)
 	k.idToKeys.Insert(id, key)
 	return previousKey
 }
 
 // RemoveKey removes the public key with the given Key ID from the database
-func (k *Keys) RemoveKey(id KeyID) crypto.PublicKey {
+func (k *MemoryKeysDB) RemoveKey(id KeyID) crypto.PublicKey {
 	previousKey, _ := k.idToKeys.Get(id)
 	k.idToKeys.Remove(id)
 	return previousKey
@@ -103,7 +109,7 @@ func (k *Keys) RemoveKey(id KeyID) crypto.PublicKey {
 
 // GetKey returns the public key with the given Key ID from the database
 // Returns nil if none was found
-func (k *Keys) GetKey(id KeyID) crypto.PublicKey {
+func (k *MemoryKeysDB) GetKey(id KeyID) crypto.PublicKey {
 	key, ok := k.idToKeys.Get(id)
 	if !ok {
 		return nil

--- a/signature.go
+++ b/signature.go
@@ -396,7 +396,7 @@ func ExtractSignature(r *http.Request) (*Signature, error) {
 	return ParseSignatureAuthorizationContent(authHeader)
 }
 
-func VerifySignature(keysDB *Keys, r *http.Request) (bool, error) {
+func VerifySignature(keysDB KeysDB, r *http.Request) (bool, error) {
 	signatureCandidate, err := ExtractSignature(r)
 	if err != nil {
 		return false, err
@@ -426,7 +426,7 @@ func VerifySignature(keysDB *Keys, r *http.Request) (bool, error) {
 	return VerifySignatureWithMaterial(keysDB, signatureCandidate, &material)
 }
 
-func VerifySignatureWithMaterial(keysDB *Keys, signatureCandidate *Signature, material *TLSExporterMaterial) (bool, error) {
+func VerifySignatureWithMaterial(keysDB KeysDB, signatureCandidate *Signature, material *TLSExporterMaterial) (bool, error) {
 	log.Debug().Msgf("Verifying signature with key ID %s, proof=%s, exporter_material=<%s>", b64Encoder.EncodeToString([]byte(signatureCandidate.keyID)),
 		b64Encoder.EncodeToString(signatureCandidate.proof), material)
 	key := keysDB.GetKey(signatureCandidate.keyID)

--- a/signature_test.go
+++ b/signature_test.go
@@ -18,7 +18,7 @@ func TestVerifySignatureWithExistingMaterial(t *testing.T) {
 	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	Expect(err).ToNot(HaveOccurred())
 	rsaKeyID := "testKeyIDrsa"
-	keys := NewKeysDatabase()
+	keys := NewMemoryKeysDatabase()
 	keys.AddKey(KeyID(rsaKeyID), &rsaKey.PublicKey)
 
 	ecdsaKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -62,10 +62,10 @@ func TestParseSignatureAuthorizationPayload(t *testing.T) {
 
 	// these values come from the example in https://www.ietf.org/archive/id/draft-ietf-httpbis-unprompted-auth-05.html
 	/*
-	*/
+	 */
 	stringVal := "Signature k=YmFzZW1lbnQ, a=VGhpcyBpcyBh-HB1YmxpYyBrZXkgaW4gdXNl_GhlcmU, " +
-	    "s=2055, v=dmVyaWZpY2F0aW9u_zE2Qg, p=SW5zZXJ0_HNpZ25hdHVyZSBvZiBub25jZSBoZXJlIHdo" +
-	    "aWNoIHRha2VzIDUxMiBiaXRz-GZvciBFZDI1NTE5IQ"
+		"s=2055, v=dmVyaWZpY2F0aW9u_zE2Qg, p=SW5zZXJ0_HNpZ25hdHVyZSBvZiBub25jZSBoZXJlIHdo" +
+		"aWNoIHRha2VzIDUxMiBiaXRz-GZvciBFZDI1NTE5IQ"
 
 	decodedKeyId := "basement"
 	decodedPubKey := "This is a\xF8public key in use\xFChere"
@@ -79,6 +79,5 @@ func TestParseSignatureAuthorizationPayload(t *testing.T) {
 	Expect([]byte(signature.pubkey.(ed25519.PublicKey))).To(BeEquivalentTo([]uint8(decodedPubKey)))
 	Expect(signature.exporterVerification).To(BeEquivalentTo(decodedVerification))
 	Expect(signature.proof).To(BeEquivalentTo(decodedSignature))
-
 
 }


### PR DESCRIPTION
This PR turns the `KeyDB` into an interface with the map/memory-backed database being one possible implementation. It allows for the key database to be anything, e.g. RDBMS, or Redis.